### PR TITLE
feat(security): 添加API令牌验证与构建时安全配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ captures
 *.keystore
 *.jks
 keystore.properties
+local.properties
+auth.properties
 
 # FolkPatch specific signing files
 app/folkpatch-release*.jks

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,9 +152,29 @@ android {
                 cppFlags += baseFlags + "-std=c++2b"
                 cFlags += baseFlags + "-std=c2x"
                 arguments += baseArgs
+                
+                // Pass Token and Signature Hash to CMake
+                val authProps = Properties()
+                val authFile = rootProject.file("auth.properties")
+                if (authFile.exists()) {
+                    authProps.load(FileInputStream(authFile))
+                }
+                val token = authProps.getProperty("api.token", "")
+                val signatureHash = authProps.getProperty("app.signature.hash", "")
+                
+                // Pass to C++ compiler directly via flags
+                cppFlags += listOf(
+                    "-DAPI_TOKEN=\"$token\"", 
+                    "-DAPP_SIGNATURE_HASH=\"$signatureHash\"",
+                    "-DAPP_PACKAGE_NAME=\"$applicationId\""
+                )
+                
                 abiFilters("arm64-v8a")
             }
         }
+        
+        // Pass Signature Hash to Java
+        buildConfigField("String", "APP_SIGNATURE_HASH", "\"${localProperties.getProperty("app.signature.hash", "")}\"")
     }
 
     compileOptions {

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CHERISH_POLLY_FLAGS} -ffunction-sections -
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CHERISH_POLLY_FLAGS} -ffunction-sections -fdata-sections -fvisibility=hidden -fvisibility-inlines-hidden -fno-rtti -fno-exceptions -O3 -flto -Wno-vla-cxx-extension -finput-charset=UTF-8 -fexec-charset=UTF-8")
 set(CMAKE_CXX_STANDARD 23)
 
-add_library(${PROJECT_NAME} SHARED apjni.cpp)
+add_library(${PROJECT_NAME} SHARED apjni.cpp security.cpp)
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_STRIP} --strip-all --remove-section=.note.gnu.build-id --remove-section=.note.android.ident $<TARGET_FILE:${PROJECT_NAME}>)
 

--- a/app/src/main/cpp/apjni.cpp
+++ b/app/src/main/cpp/apjni.cpp
@@ -10,6 +10,7 @@
 
 #include "apjni.hpp"
 #include "supercall.h"
+#include "security.hpp"
 
 jboolean nativeReady(JNIEnv *env, jobject /* this */, jstring super_key_jstr) {
     ensureSuperKeyNonNull(super_key_jstr);
@@ -282,6 +283,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void * /*reserved*/) {
         {"nativeRevokeSu", "(Ljava/lang/String;I)J", reinterpret_cast<void *>(&nativeRevokeSu)},
         {"nativeSuPath", "(Ljava/lang/String;)Ljava/lang/String;", reinterpret_cast<void *>(&nativeSuPath)},
         {"nativeResetSuPath", "(Ljava/lang/String;Ljava/lang/String;)Z", reinterpret_cast<void *>(&nativeResetSuPath)},
+        {"nativeGetApiToken", "(Landroid/content/Context;)Ljava/lang/String;", reinterpret_cast<void *>(&nativeGetApiToken)},
     };
 
     if (JNI_RegisterNatives(env, clazz, gMethods, sizeof(gMethods) / sizeof(gMethods[0])) < 0) [[unlikely]] {

--- a/app/src/main/cpp/security.cpp
+++ b/app/src/main/cpp/security.cpp
@@ -1,0 +1,137 @@
+#include "security.hpp"
+#include <string>
+#include <cstring>
+#include <strings.h>
+#include <android/log.h>
+#include <jni.h>
+#include <vector>
+
+#define LOG_TAG "APSecurity"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+
+#ifndef API_TOKEN
+#define API_TOKEN ""
+#endif
+
+#ifndef APP_SIGNATURE_HASH
+#define APP_SIGNATURE_HASH ""
+#endif
+
+#ifndef APP_PACKAGE_NAME
+#define APP_PACKAGE_NAME ""
+#endif
+
+// Helper to convert byte array to hex string
+std::string bytesToHex(JNIEnv *env, jbyteArray bytes) {
+    jsize length = env->GetArrayLength(bytes);
+    jbyte *elements = env->GetByteArrayElements(bytes, nullptr);
+    std::string out;
+    out.reserve(static_cast<size_t>(length) * 2);
+    static const char HEX[] = "0123456789abcdef";
+    for (int i = 0; i < length; ++i) {
+        unsigned char b = static_cast<unsigned char>(elements[i]);
+        out.push_back(HEX[(b >> 4) & 0x0F]);
+        out.push_back(HEX[b & 0x0F]);
+    }
+    env->ReleaseByteArrayElements(bytes, elements, JNI_ABORT);
+    return out;
+}
+
+std::string getSignatureHash(JNIEnv *env, jobject context) {
+    jclass contextClass = env->GetObjectClass(context);
+    jmethodID getPackageManager = env->GetMethodID(contextClass, "getPackageManager", "()Landroid/content/pm/PackageManager;");
+    jobject packageManager = env->CallObjectMethod(context, getPackageManager);
+    
+    jmethodID getPackageName = env->GetMethodID(contextClass, "getPackageName", "()Ljava/lang/String;");
+    jstring packageName = (jstring)env->CallObjectMethod(context, getPackageName);
+    
+    jclass packageManagerClass = env->GetObjectClass(packageManager);
+    jmethodID getPackageInfo = env->GetMethodID(packageManagerClass, "getPackageInfo", "(Ljava/lang/String;I)Landroid/content/pm/PackageInfo;");
+    
+    // GET_SIGNATURES = 64
+    jobject packageInfo = env->CallObjectMethod(packageManager, getPackageInfo, packageName, 64);
+    
+    if (packageInfo == nullptr) {
+        LOGE("Failed to get PackageInfo");
+        return "";
+    }
+    
+    jclass packageInfoClass = env->GetObjectClass(packageInfo);
+    jfieldID signaturesField = env->GetFieldID(packageInfoClass, "signatures", "[Landroid/content/pm/Signature;");
+    jobjectArray signatures = (jobjectArray)env->GetObjectField(packageInfo, signaturesField);
+    
+    if (signatures == nullptr) {
+        LOGE("Failed to get signatures");
+        return "";
+    }
+    
+    jobject signature = env->GetObjectArrayElement(signatures, 0);
+    jclass signatureClass = env->GetObjectClass(signature);
+    jmethodID toByteArray = env->GetMethodID(signatureClass, "toByteArray", "()[B");
+    jbyteArray signatureBytes = (jbyteArray)env->CallObjectMethod(signature, toByteArray);
+    
+    // Calculate SHA-256
+    jclass messageDigestClass = env->FindClass("java/security/MessageDigest");
+    jmethodID getInstance = env->GetStaticMethodID(messageDigestClass, "getInstance", "(Ljava/lang/String;)Ljava/security/MessageDigest;");
+    jobject messageDigest = env->CallStaticObjectMethod(messageDigestClass, getInstance, env->NewStringUTF("SHA-256"));
+    
+    jmethodID digestMethod = env->GetMethodID(messageDigestClass, "digest", "([B)[B");
+    jbyteArray hashBytes = (jbyteArray)env->CallObjectMethod(messageDigest, digestMethod, signatureBytes);
+    
+    return bytesToHex(env, hashBytes);
+}
+
+std::string getPackageName(JNIEnv *env, jobject context) {
+    jclass contextClass = env->GetObjectClass(context);
+    jmethodID getPackageNameMethod = env->GetMethodID(contextClass, "getPackageName", "()Ljava/lang/String;");
+    jstring packageName = (jstring)env->CallObjectMethod(context, getPackageNameMethod);
+    
+    const char *pkgNameChars = env->GetStringUTFChars(packageName, 0);
+    std::string pkgNameStr(pkgNameChars);
+    env->ReleaseStringUTFChars(packageName, pkgNameChars);
+    
+    return pkgNameStr;
+}
+
+jstring nativeGetApiToken(JNIEnv *env, jobject thiz, jobject context) {
+    if (context == nullptr) {
+        LOGE("Context is null");
+        return env->NewStringUTF("");
+    }
+    
+    // 1. Verify Package Name
+    std::string currentPkg = getPackageName(env, context);
+    std::string expectedPkg = XSTR(APP_PACKAGE_NAME);
+    
+    // Simple protection: if expected is empty (not set), fail safe or warn?
+    // User said "verify software package name".
+    if (expectedPkg.empty()) {
+        LOGE("Expected package name is not set in build config");
+         // For now allow it if not configured? No, user wants security.
+         // But during development, maybe they didn't set it.
+         // Let's assume strict.
+    }
+    
+    if (currentPkg != expectedPkg) {
+        LOGE("Package name mismatch! Expected: %s, Got: %s", expectedPkg.c_str(), currentPkg.c_str());
+        return env->NewStringUTF("");
+    }
+    
+    // 2. Verify Signature
+    std::string currentHash = getSignatureHash(env, context);
+    std::string expectedHash = XSTR(APP_SIGNATURE_HASH); // SHA-256 hex string
+    
+    if (expectedHash.empty()) {
+         LOGI("Expected signature hash is empty, skipping verification (Development Mode)");
+    } else {
+        // Case insensitive comparison
+        if (strcasecmp(currentHash.c_str(), expectedHash.c_str()) != 0) {
+            LOGE("Signature mismatch! Expected: %s, Got: %s", expectedHash.c_str(), currentHash.c_str());
+            return env->NewStringUTF("");
+        }
+    }
+    
+    // 3. Return Token
+    return env->NewStringUTF(XSTR(API_TOKEN));
+}

--- a/app/src/main/cpp/security.hpp
+++ b/app/src/main/cpp/security.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <jni.h>
+
+#define XSTR(s) STR(s)
+#define STR(s) #s
+
+jstring nativeGetApiToken(JNIEnv *env, jobject thiz, jobject context);

--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -298,7 +298,10 @@ class APApplication : Application(), Thread.UncaughtExceptionHandler, ImageLoade
         }
 
         Log.d(TAG, "Checking app signature...")
-        if (!BuildConfig.DEBUG && !verifyAppSignature("a9eba5b702eb55fb5f4b1a672a7133a16a7bcaea949cde43c812ef26c77de812")) {
+        val expectedSignature = BuildConfig.APP_SIGNATURE_HASH.ifEmpty { 
+            "a9eba5b702eb55fb5f4b1a672a7133a16a7bcaea949cde43c812ef26c77de812" 
+        }
+        if (!BuildConfig.DEBUG && !verifyAppSignature(expectedSignature)) {
             Log.e(TAG, "App signature verification failed!")
             isSignatureValid = false
         }

--- a/app/src/main/java/me/bmax/apatch/Natives.kt
+++ b/app/src/main/java/me/bmax/apatch/Natives.kt
@@ -1,6 +1,7 @@
 package me.bmax.apatch
 
 import android.os.Parcelable
+import android.content.Context
 import androidx.annotation.Keep
 import androidx.compose.runtime.Immutable
 import dalvik.annotation.optimization.FastNative
@@ -151,5 +152,10 @@ object Natives {
     private external fun nativeResetSuPath(superKey: String, path: String): Boolean
     fun resetSuPath(path: String): Boolean {
         return nativeResetSuPath(APApplication.superKey, path)
+    }
+
+    external fun nativeGetApiToken(context: Context): String
+    fun getApiToken(context: Context): String {
+        return nativeGetApiToken(context)
     }
 }

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/OnlineKPMViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/OnlineKPMViewModel.kt
@@ -56,7 +56,8 @@ class OnlineKPMViewModel : ViewModel() {
                 val locale = Locale.getDefault()
                 val language = locale.language
                 val lang = if (language == "zh" || language == "mgl") "zh" else "en"
-                val url = "$MODULES_URL&lang=$lang"
+                val token = me.bmax.apatch.Natives.getApiToken(apApp)
+                val url = "$MODULES_URL&lang=$lang&token=$token"
 
                 val response = apApp.okhttpClient.newCall(
                     okhttp3.Request.Builder().url(url).build()

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/OnlineModuleViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/OnlineModuleViewModel.kt
@@ -65,7 +65,8 @@ class OnlineModuleViewModel : ViewModel() {
                 val locale = Locale.getDefault()
                 val language = locale.language
                 val lang = if (language == "zh" || language == "mgl") "zh" else "en"
-                val url = "$MODULES_URL&lang=$lang"
+                val token = me.bmax.apatch.Natives.getApiToken(apApp)
+                val url = "$MODULES_URL&lang=$lang&token=$token"
 
                 val response = apApp.okhttpClient.newCall(
                     okhttp3.Request.Builder().url(url).build()

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/OnlineScriptViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/OnlineScriptViewModel.kt
@@ -55,7 +55,8 @@ class OnlineScriptViewModel : ViewModel() {
                 val locale = Locale.getDefault()
                 val language = locale.language
                 val lang = if (language == "zh" || language == "mgl") "zh" else "en"
-                val url = "$MODULES_URL&lang=$lang"
+                val token = me.bmax.apatch.Natives.getApiToken(apApp)
+                val url = "$MODULES_URL&lang=$lang&token=$token"
 
                 val response = apApp.okhttpClient.newCall(
                     okhttp3.Request.Builder().url(url).build()

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/ThemeStoreViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/ThemeStoreViewModel.kt
@@ -104,8 +104,10 @@ class ThemeStoreViewModel : ViewModel() {
             isRefreshing = true
             errorMessage = null
             try {
+                val token = me.bmax.apatch.Natives.getApiToken(apApp)
+                val url = if (THEMES_URL.contains("?")) "$THEMES_URL&token=$token" else "$THEMES_URL?token=$token"
                 val request = okhttp3.Request.Builder()
-                    .url(THEMES_URL)
+                    .url(url)
                     .build()
                 
                 val response = apApp.okhttpClient.newCall(request).execute()

--- a/auth.properties.template
+++ b/auth.properties.template
@@ -1,0 +1,5 @@
+# API Token Configuration
+# 请填入服务端Token
+api.token=YOUR_SERVER_TOKEN_HERE
+# 请填入应用签名Hash (SHA-256)
+app.signature.hash=YOUR_APP_SIGNATURE_HASH_HERE

--- a/keystore.properties.template
+++ b/keystore.properties.template
@@ -6,3 +6,4 @@ KEYSTORE_FILE=../app/your-keystore.jks
 KEYSTORE_PASSWORD=your-keystore-password
 KEY_ALIAS=your-key-alias
 KEY_PASSWORD=your-key-password
+

--- a/local.properties.template
+++ b/local.properties.template
@@ -1,0 +1,10 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#
+# sdk.dir=/path/to/your/android/sdk
+debug.fake_root=false
+


### PR DESCRIPTION
- 新增安全模块，通过native代码验证应用包名和签名
- 添加auth.properties和local.properties模板文件用于配置
- 修改在线功能请求URL，自动附加API令牌参数
- 更新构建配置，支持从属性文件读取令牌和签名哈希
- 改进应用签名验证逻辑，支持通过构建配置自定义预期签名