### PR TITLE
feat: KPM 自动加载、CI/CD 统一重构及 Bug 修复

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -1,0 +1,36 @@
+name: Setup Build Environment
+description: Install all build dependencies (Java, Android SDK, Gradle, Rust toolchain)
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+
+    - uses: android-actions/setup-android@v3
+
+    - uses: gradle/actions/setup-gradle@v3
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: aarch64-linux-android
+        override: true
+
+    - name: Install cargo-ndk
+      shell: bash
+      run: cargo install cargo-ndk
+
+    - name: Grant execute permission
+      shell: bash
+      run: chmod +x gradlew
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: ${{ runner.os }}-gradle-

--- a/.github/workflows/CI_up.yml
+++ b/.github/workflows/CI_up.yml
@@ -17,6 +17,7 @@ jobs:
   upload:
     name: Upload to Telegram
     runs-on: ubuntu-latest
+    if: ${{ vars.TELEGRAM_ENABLED == 'true' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ env:
   KEYSTORE_PASSWORD: android
   KEY_ALIAS: androiddebugkey
   KEY_PASSWORD: android
-  ZIG_EXE: /opt/hostedtoolcache/zig/master/x64/zig
 
 jobs:
   prepare:
@@ -59,126 +58,54 @@ jobs:
           esac
           echo "text=$TEXT" >> "$GITHUB_OUTPUT"
 
-  build-debug:
+  build:
     needs: prepare
-    if: needs.prepare.outputs.build_debug == 'true'
+    if: needs.prepare.outputs.build_debug == 'true' || needs.prepare.outputs.build_release == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - type: debug
+            task: assembleDebug
+            artifact_name: folkpatch-debug-${{ github.sha }}
+            apk_prefix: FolkPatch-Debug
+            apk_dir: debug
+            enabled: ${{ needs.prepare.outputs.build_debug == 'true' }}
+          - type: release
+            task: assembleRelease
+            artifact_name: folkpatch-release-${{ github.sha }}
+            apk_prefix: FolkPatch-Release
+            apk_dir: release
+            enabled: ${{ needs.prepare.outputs.build_release == 'true' }}
 
     steps:
+      - name: Skip disabled build type
+        if: matrix.enabled != 'true'
+        run: echo "Skipping ${{ matrix.type }} build" && exit 0
+
       - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
+      - uses: ./.github/actions/setup-build-env
 
-      - uses: android-actions/setup-android@v3
+      - run: ./gradlew ${{ matrix.task }} --no-daemon
 
-      - uses: gradle/actions/setup-gradle@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: aarch64-linux-android
-          override: true
-
-      - run: cargo install cargo-ndk
-
-      - uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: master
-
-      - run: chmod +x gradlew
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
-
-      - run: ./gradlew assembleDebug --no-daemon
-
-      - name: Rename Debug APK
+      - name: Rename APK
         run: |
           SHORT="${GITHUB_SHA::7}"
-          mv app/build/outputs/apk/debug/*.apk "FolkPatch-Debug-${SHORT}.apk"
+          mv app/build/outputs/apk/${{ matrix.apk_dir }}/*.apk "${{ matrix.apk_prefix }}-${SHORT}.apk"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: folkpatch-debug-${{ github.sha }}
-          path: FolkPatch-Debug-*.apk
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.apk_prefix }}-*.apk
           retention-days: 30
-
-  build-release:
-    needs: prepare
-    if: needs.prepare.outputs.build_release == 'true'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
-
-      - uses: android-actions/setup-android@v3
-
-      - uses: gradle/actions/setup-gradle@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: aarch64-linux-android
-          override: true
-
-      - run: cargo install cargo-ndk
-
-      - uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: master
-
-      - run: chmod +x gradlew
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
-
-      - run: ./gradlew assembleRelease --no-daemon
-
-      - name: Rename Release APK
-        run: |
-          SHORT="${GITHUB_SHA::7}"
-          mv app/build/outputs/apk/release/*.apk "FolkPatch-Release-${SHORT}.apk"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: folkpatch-release-${{ github.sha }}
-          path: FolkPatch-Release-*.apk
-          retention-days: 30
-
-      - name: Create Release (if tagged)
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: app/build/outputs/apk/release/*.apk
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload:
-    needs: [prepare, build-debug, build-release]
-    if: always() && needs.prepare.result == 'success' && (needs.build-debug.result == 'success' || needs.build-release.result == 'success') && github.actor != 'dependabot[bot]'
+    needs: [prepare, build]
+    if: always() && needs.prepare.result == 'success' && (needs.build.jobs.debug.result == 'success' || needs.build.jobs.release.result == 'success') && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/CI_up.yml
     with:
       artifact_names: ${{ needs.prepare.outputs.artifact_list }}

--- a/apd/src/defs.rs
+++ b/apd/src/defs.rs
@@ -36,6 +36,10 @@ pub const METAMODULE_METAINSTALL_SCRIPT: &str = "metainstall.sh";
 pub const METAMODULE_METAUNINSTALL_SCRIPT: &str = "metauninstall.sh";
 pub const METAMODULE_DIR: &str = concatcp!(ADB_DIR, "metamodule/");
 
+pub const FP_KPMS_DIR: &str = concatcp!(ADB_DIR, "fp/kpms/");
+pub const FP_KPMS_AUTOLOAD_DIR: &str = concatcp!(ADB_DIR, "fp/kpms/autoload/");
+pub const KPM_AUTOLOAD_CONFIG: &str = concatcp!(ADB_DIR, "fp/kpms/kpm_autoload_config.json");
+
 pub const PTS_NAME: &str = "pts";
 
 pub const VERSION_CODE: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_CODE"));

--- a/apd/src/event.rs
+++ b/apd/src/event.rs
@@ -41,11 +41,12 @@ pub fn report_kernel(superkey: Option<String>, event: &str, state: &str) -> Resu
 pub fn on_post_data_fs(superkey: Option<String>) -> Result<()> {
     utils::umask(0);
     report_kernel(superkey.clone(), "post-fs-data", "before")?;
-    use std::process::Stdio;
 
     // Create /data/adb/fp/bin directory for fpd binary
     let fp_dir = Path::new("/data/adb/fp");
     let fp_bin_dir = Path::new("/data/adb/fp/bin");
+    let fp_kpms_dir = Path::new(defs::FP_KPMS_DIR);
+    let fp_kpms_autoload_dir = Path::new(defs::FP_KPMS_AUTOLOAD_DIR);
     if !fp_bin_dir.exists() {
         fs::create_dir_all(fp_bin_dir)
             .with_context(|| "Failed to create /data/adb/fp/bin directory")?;
@@ -55,6 +56,16 @@ pub fn on_post_data_fs(superkey: Option<String>) -> Result<()> {
         fs::set_permissions(fp_bin_dir, permissions)
             .with_context(|| "Failed to set permissions for /data/adb/fp/bin")?;
         info!("Created directory: /data/adb/fp/bin");
+    }
+    if !fp_kpms_autoload_dir.exists() {
+        fs::create_dir_all(fp_kpms_autoload_dir)
+            .with_context(|| "Failed to create /data/adb/fp/kpms/autoload directory")?;
+        let permissions = fs::Permissions::from_mode(0o755);
+        fs::set_permissions(fp_kpms_dir, permissions.clone())
+            .with_context(|| "Failed to set permissions for /data/adb/fp/kpms")?;
+        fs::set_permissions(fp_kpms_autoload_dir, permissions)
+            .with_context(|| "Failed to set permissions for /data/adb/fp/kpms/autoload")?;
+        info!("Created directory: /data/adb/fp/kpms/autoload");
     }
 
     init_load_su_path(&superkey);
@@ -287,6 +298,9 @@ fn run_stage(stage: &str, superkey: Option<String>, block: bool) {
 
 pub fn on_services(superkey: Option<String>) -> Result<()> {
     info!("on_services triggered!");
+
+    supercall::autoload_kpm_modules(&superkey);
+
     run_stage("service", superkey, false);
 
     Ok(())

--- a/apd/src/supercall.rs
+++ b/apd/src/supercall.rs
@@ -27,6 +27,8 @@ const SUPERCALL_SU_LIST: c_long = 0x1103;
 const SUPERCALL_SU_RESET_PATH: c_long = 0x1111;
 const SUPERCALL_SU_GET_SAFEMODE: c_long = 0x1112;
 
+const SUPERCALL_KPM_LOAD: c_long = 0x1020;
+
 const SUPERCALL_SCONTEXT_LEN: usize = 0x60;
 
 #[repr(C)]
@@ -149,6 +151,22 @@ fn sc_su_reset_path(key: &CStr, path: &CStr) -> c_long {
             key.as_ptr(),
             ver_and_cmd(SUPERCALL_SU_RESET_PATH),
             path.as_ptr(),
+        ) as c_long
+    }
+}
+
+fn sc_kpm_load(key: &CStr, path: &CStr, args: &CStr) -> c_long {
+    if key.to_bytes().is_empty() || path.to_bytes().is_empty() {
+        return (-EINVAL).into();
+    }
+    unsafe {
+        syscall(
+            __NR_SUPERCALL,
+            key.as_ptr(),
+            ver_and_cmd(SUPERCALL_KPM_LOAD),
+            path.as_ptr(),
+            args.as_ptr(),
+            std::ptr::null::<c_void>(),
         ) as c_long
     }
 }
@@ -303,4 +321,109 @@ pub fn init_load_su_path(superkey: &Option<String>) {
             warn!("Failed to read su_path file: {}", e);
         }
     }
+}
+
+pub fn autoload_kpm_modules(superkey: &Option<String>) {
+    use serde::Deserialize;
+
+    #[derive(Deserialize, Default)]
+    struct KpmAutoLoadConfig {
+        enabled: bool,
+        #[serde(default, rename = "kpmPaths")]
+        kpm_paths: Vec<String>,
+    }
+
+    let config_path = crate::defs::KPM_AUTOLOAD_CONFIG;
+    let content = match std::fs::read_to_string(config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            info!("[kpm_autoload] config not found or unreadable ({}): {}", config_path, e);
+            return;
+        }
+    };
+
+    let config: KpmAutoLoadConfig = match serde_json::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("[kpm_autoload] failed to parse config: {}", e);
+            return;
+        }
+    };
+
+    if !config.enabled || config.kpm_paths.is_empty() {
+        info!("[kpm_autoload] disabled or no paths configured, skipping");
+        return;
+    }
+
+    let key = convert_superkey(superkey);
+    let key = match key {
+        Some(k) => k,
+        None => {
+            warn!("[kpm_autoload] no superkey available");
+            return;
+        }
+    };
+
+    let empty_args = match CString::new("") {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    const MAX_KPM_MODULES: usize = 64;
+
+    if config.kpm_paths.len() > MAX_KPM_MODULES {
+        warn!(
+            "[kpm_autoload] too many paths ({}), truncating to {}",
+            config.kpm_paths.len(),
+            MAX_KPM_MODULES
+        );
+    }
+
+    let mut success = 0u32;
+    let mut fail = 0u32;
+    for path_str in config.kpm_paths.iter().take(MAX_KPM_MODULES) {
+        if !std::path::Path::new(path_str).exists() {
+            warn!("[kpm_autoload] file not found: {}", path_str);
+            fail += 1;
+            continue;
+        }
+
+        let canonical = match std::fs::canonicalize(path_str) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("[kpm_autoload] cannot canonicalize '{}': {}", path_str, e);
+                fail += 1;
+                continue;
+            }
+        };
+
+        let allowed_dir = std::path::Path::new(crate::defs::FP_KPMS_AUTOLOAD_DIR);
+        if !canonical.starts_with(allowed_dir) {
+            warn!(
+                "[kpm_autoload] path '{}' outside allowed directory '{}', skipping",
+                path_str,
+                crate::defs::FP_KPMS_AUTOLOAD_DIR
+            );
+            fail += 1;
+            continue;
+        }
+
+        let path_cstr = match CString::new(canonical.to_string_lossy().into_owned()) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("[kpm_autoload] invalid canonical path: {}", e);
+                fail += 1;
+                continue;
+            }
+        };
+        let rc = sc_kpm_load(&key, &path_cstr, &empty_args);
+        if rc == 0 {
+            success += 1;
+            info!("[kpm_autoload] loaded: {}", path_str);
+        } else {
+            fail += 1;
+            warn!("[kpm_autoload] failed to load '{}', rc={}", path_str, rc);
+        }
+    }
+    info!("[kpm_autoload] done: success={}, fail={}", success, fail);
 }

--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.topjohnwu.superuser.CallbackList
 import me.bmax.apatch.ui.CrashHandleActivity
-import me.bmax.apatch.ui.component.KpmAutoLoadManager
 import me.bmax.apatch.util.APatchCli
 import me.bmax.apatch.util.APatchKeyHelper
 import me.bmax.apatch.ui.theme.MusicConfig
@@ -280,24 +279,6 @@ class APApplication : Application(), Thread.UncaughtExceptionHandler, ImageLoade
                         _apStateLiveData.postValue(State.ANDROIDPATCH_NOT_INSTALLED)
                     }
                     Log.d(TAG, "ap state: " + _apStateLiveData.value)
-                    
-                    // 执行KPM自动加载 - 确保在合适的时机执行
-                    Log.d(TAG, "Preparing KPM auto-load...")
-                    // 调试配置状态
-                    KpmAutoLoadManager.debugConfigState()
-                    
-                    // 在新的线程中执行，避免阻塞主流程
-                    thread {
-                        try {
-                            // 确保配置已经正确加载
-                            Thread.sleep(1000) // 等待更长时间确保所有初始化完成
-                            Log.d(TAG, "Executing KPM auto-load...")
-                            val result = KpmAutoLoadManager.autoLoadKpmModules()
-                            Log.d(TAG, "KPM auto-load result: $result")
-                        } catch (e: Exception) {
-                            Log.e(TAG, "KPM auto-load failed: ${e.message}", e)
-                        }
-                    }
 
                     return@thread
                 }
@@ -339,11 +320,6 @@ class APApplication : Application(), Thread.UncaughtExceptionHandler, ImageLoade
         Log.d(TAG, "Reading superKey...")
         superKey = APatchKeyHelper.readSPSuperKey()
         Log.d(TAG, "superKey read completed, length=${superKey.length}")
-        
-        // 加载KPM自动加载配置 - 确保在superKey设置之前加载
-        Log.d(TAG, "Loading KPM auto-load configuration...")
-        val kpmConfig = KpmAutoLoadManager.loadConfig(this)
-        Log.d(TAG, "KPM config loaded: enabled=${kpmConfig.enabled}, paths=${kpmConfig.kpmPaths.size}")
 
         Log.d(TAG, "Initializing OkHttpClient...")
         okhttpClient =

--- a/app/src/main/java/me/bmax/apatch/ui/component/KpmAutoLoadConfig.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/component/KpmAutoLoadConfig.kt
@@ -3,109 +3,100 @@ package me.bmax.apatch.ui.component
 import android.content.Context
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.graphics.Color
-import me.bmax.apatch.APApplication
-import me.bmax.apatch.apApp
 import me.bmax.apatch.util.SafeUriResolver
+import me.bmax.apatch.util.getRootShell
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
-import java.io.FileReader
-import java.io.FileWriter
-import java.io.IOException
+import java.io.FileOutputStream
+import android.util.Base64
 
-/**
- * KPM自动加载配置数据类
- */
 data class KpmAutoLoadConfig(
     val enabled: Boolean = false,
     val kpmPaths: List<String> = emptyList()
 )
 
-/**
- * KPM自动加载配置管理器
- */
 object KpmAutoLoadManager {
     private const val TAG = "KpmAutoLoadManager"
-    private const val CONFIG_FILE_NAME = "kpm_autoload_config.json"
     private const val PREFS_NAME = "kpm_autoload_prefs"
     private const val KEY_FIRST_TIME_SHOWN = "first_time_shown"
     private const val KEY_FIRST_TIME_KPM_PAGE_SHOWN = "first_time_kpm_page_shown"
-    private const val KPMS_DIR_NAME = "autoload_kpms"
-    
-    // 当前配置状态
+    private const val KPMS_BASE_DIR = "/data/adb/fp/kpms"
+    private const val KPMS_AUTOLOAD_DIR = "/data/adb/fp/kpms/autoload"
+    private const val CONFIG_PATH = "/data/adb/fp/kpms/kpm_autoload_config.json"
+
     var isEnabled = mutableStateOf(false)
         private set
     var kpmPaths = mutableStateOf<List<String>>(emptyList())
         private set
-    
-    /**
-     * 检查是否是首次使用
-     */
+
     fun isFirstTime(context: Context): Boolean {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         return !prefs.getBoolean(KEY_FIRST_TIME_SHOWN, false)
     }
-    
-    /**
-     * 标记首次提示已显示
-     */
+
     fun setFirstTimeShown(context: Context) {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        prefs.edit().putBoolean(KEY_FIRST_TIME_SHOWN, true).apply()
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_FIRST_TIME_SHOWN, true).apply()
     }
 
-    /**
-     * 检查KPM页面是否是首次使用
-     */
     fun isFirstTimeKpmPage(context: Context): Boolean {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        return !prefs.getBoolean(KEY_FIRST_TIME_KPM_PAGE_SHOWN, false)
+        return !context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_FIRST_TIME_KPM_PAGE_SHOWN, false)
     }
 
-    /**
-     * 标记KPM页面首次提示已显示
-     */
     fun setFirstTimeKpmPageShown(context: Context) {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        prefs.edit().putBoolean(KEY_FIRST_TIME_KPM_PAGE_SHOWN, true).apply()
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_FIRST_TIME_KPM_PAGE_SHOWN, true).apply()
     }
-    
-    /**
-     * 导入KPM文件到内部存储
-     */
+
     fun importKpm(context: Context, uri: android.net.Uri): String? {
-        return try {
-            val kpmDir = File(context.filesDir, KPMS_DIR_NAME)
-            if (!kpmDir.exists()) {
-                kpmDir.mkdirs()
-            }
+        val rawFileName = getFileName(context, uri) ?: "unknown_${System.currentTimeMillis()}.kpm"
+        val safeFileName = rawFileName.replace(Regex("[^a-zA-Z0-9._\\-]"), "_")
+            .ifEmpty { "unknown_${System.currentTimeMillis()}.kpm" }
+        val finalFileName = if (!safeFileName.endsWith(".kpm", ignoreCase = true))
+            "${safeFileName}.kpm" else safeFileName
 
-            val fileName = getFileName(context, uri) ?: "unknown_${System.currentTimeMillis()}.kpm"
-            val destFile = File(kpmDir, fileName)
-            
-            // 如果文件已存在，先删除
-            if (destFile.exists()) {
-                destFile.delete()
-            }
+        var destPath = "$KPMS_AUTOLOAD_DIR/$finalFileName"
+        val tempFile = File(context.cacheDir, finalFileName)
 
+        try {
             SafeUriResolver.openInputStream(context, uri)?.use { input ->
-                destFile.outputStream().use { output ->
+                FileOutputStream(tempFile).use { output ->
                     input.copyTo(output)
                 }
+            } ?: return null
+
+            val shell = getRootShell()
+
+            val existsOutList = java.util.ArrayList<String>()
+            val existsResult = shell.newJob().add("test -f '$destPath' && echo 1 || echo 0").to(existsOutList, null).exec()
+            if (existsResult.isSuccess && existsOutList.any { it.trim() == "1" }) {
+                val baseName = finalFileName.substringBeforeLast(".", finalFileName)
+                destPath = "$KPMS_AUTOLOAD_DIR/${baseName}_${System.currentTimeMillis()}.kpm"
             }
-            
-            Log.d(TAG, "KPM导入成功: ${destFile.absolutePath}")
-            destFile.absolutePath
+
+            val result = shell.newJob().add(
+                "mkdir -p '$KPMS_AUTOLOAD_DIR'",
+                "cp -f '${tempFile.absolutePath}' '$destPath'",
+                "chmod 644 '$destPath'"
+            ).to(null, null).exec()
+
+            return if (result.isSuccess) {
+                Log.d(TAG, "KPM导入成功: $destPath")
+                destPath
+            } else {
+                Log.e(TAG, "KPM导入失败")
+                null
+            }
         } catch (e: Exception) {
             Log.e(TAG, "KPM导入失败: ${e.message}", e)
-            null
+            return null
+        } finally {
+            tempFile.delete()
         }
     }
-    
-    /**
-     * 获取文件名
-     */
+
     private fun getFileName(context: Context, uri: android.net.Uri): String? {
         var result: String? = null
         if (uri.scheme == "content") {
@@ -113,9 +104,7 @@ object KpmAutoLoadManager {
             try {
                 if (cursor != null && cursor.moveToFirst()) {
                     val index = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                    if (index >= 0) {
-                        result = cursor.getString(index)
-                    }
+                    if (index >= 0) result = cursor.getString(index)
                 }
             } finally {
                 cursor?.close()
@@ -124,192 +113,108 @@ object KpmAutoLoadManager {
         if (result == null) {
             result = uri.path
             val cut = result?.lastIndexOf('/')
-            if (cut != null && cut != -1) {
-                result = result?.substring(cut + 1)
-            }
+            if (cut != null && cut != -1) result = result?.substring(cut + 1)
         }
         return result
     }
 
-    /**
-     * 删除不再使用的KPM文件
-     */
-    fun cleanupUnusedKpms(context: Context, currentPaths: List<String>) {
+    fun cleanupUnusedKpms(currentPaths: List<String>) {
         try {
-            val kpmDir = File(context.filesDir, KPMS_DIR_NAME)
-            if (kpmDir.exists() && kpmDir.isDirectory) {
-                kpmDir.listFiles()?.forEach { file ->
-                    if (file.absolutePath !in currentPaths) {
-                        Log.d(TAG, "删除未使用的KPM文件: ${file.absolutePath}")
-                        file.delete()
-                    }
-                }
+            val shell = getRootShell()
+            val keepSet = currentPaths.toSet()
+            val outList = java.util.ArrayList<String>()
+            val listResult = shell.newJob().add("ls -1 '$KPMS_AUTOLOAD_DIR'/*.kpm 2>/dev/null").to(outList, null).exec()
+            if (!listResult.isSuccess) return
+            outList.filter { it.isNotEmpty() && !keepSet.contains(it) }.forEach { path ->
+                shell.newJob().add("rm -f '${path.replace("'", "'\\''")}' 2>/dev/null").exec()
             }
         } catch (e: Exception) {
             Log.e(TAG, "清理KPM文件失败: ${e.message}", e)
         }
     }
 
-    /**
-     * 加载配置文件
-     */
     fun loadConfig(context: Context): KpmAutoLoadConfig {
         return try {
-            val configFile = File(context.filesDir, CONFIG_FILE_NAME)
-            if (!configFile.exists()) {
-                Log.d(TAG, "配置文件不存在，使用默认配置")
+            val shell = getRootShell()
+            val outList = java.util.ArrayList<String>()
+            val result = shell.newJob().add("cat '$CONFIG_PATH' 2>/dev/null").to(outList, null).exec()
+            if (!result.isSuccess || outList.isEmpty()) {
+                Log.d(TAG, "配置文件不存在或为空，使用默认配置")
                 return KpmAutoLoadConfig()
             }
-            
-            val reader = FileReader(configFile)
-            val jsonContent = reader.readText()
-            reader.close()
-            
+
+            val jsonContent = outList.joinToString("\n")
             val config = parseConfigFromJson(jsonContent) ?: KpmAutoLoadConfig()
             isEnabled.value = config.enabled
             kpmPaths.value = config.kpmPaths
-            Log.d(TAG, "配置加载成功: enabled=${config.enabled}, kpmPaths=${config.kpmPaths}")
             config
         } catch (e: Exception) {
             Log.e(TAG, "加载配置失败: ${e.message}", e)
-            val defaultConfig = KpmAutoLoadConfig()
-            isEnabled.value = defaultConfig.enabled
-            kpmPaths.value = defaultConfig.kpmPaths
-            defaultConfig
+            KpmAutoLoadConfig()
         }
     }
-    
-    /**
-     * 保存配置文件
-     */
+
     fun saveConfig(context: Context, config: KpmAutoLoadConfig): Boolean {
         return try {
-            val configFile = File(context.filesDir, CONFIG_FILE_NAME)
             val jsonContent = getConfigJson(config)
-            val writer = FileWriter(configFile)
-            writer.write(jsonContent)
-            writer.close()
-            
-            // 更新状态
-            isEnabled.value = config.enabled
-            kpmPaths.value = config.kpmPaths
-            Log.d(TAG, "配置保存成功: enabled=${config.enabled}, kpmPaths=${config.kpmPaths}")
-            
-            // 清理未使用的KPM文件
-            cleanupUnusedKpms(context, config.kpmPaths)
-            
-            true
-        } catch (e: IOException) {
+            val encoded = Base64.encodeToString(jsonContent.toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+
+            val shell = getRootShell()
+            val result = shell.newJob().add(
+                "mkdir -p '$KPMS_BASE_DIR'",
+                "echo '$encoded' | base64 -d > '$CONFIG_PATH'",
+                "chmod 644 '$CONFIG_PATH'"
+            ).to(null, null).exec()
+
+            if (result.isSuccess) {
+                isEnabled.value = config.enabled
+                kpmPaths.value = config.kpmPaths
+                cleanupUnusedKpms(config.kpmPaths)
+                true
+            } else {
+                Log.e(TAG, "配置保存失败")
+                false
+            }
+        } catch (e: Exception) {
             Log.e(TAG, "保存配置失败: ${e.message}", e)
             false
         }
     }
-    
-    /**
-     * 获取配置的JSON字符串
-     */
+
     fun getConfigJson(): String {
         return getConfigJson(KpmAutoLoadConfig(isEnabled.value, kpmPaths.value))
     }
-    
-    /**
-     * 获取指定配置的JSON字符串
-     */
+
     fun getConfigJson(config: KpmAutoLoadConfig): String {
         val jsonObject = JSONObject()
         jsonObject.put("enabled", config.enabled)
-        
+
         val pathsArray = JSONArray()
-        config.kpmPaths.forEach { path ->
-            pathsArray.put(path)
-        }
+        config.kpmPaths.forEach { path -> pathsArray.put(path) }
         jsonObject.put("kpmPaths", pathsArray)
-        
-        return jsonObject.toString(2) // 使用缩进格式化
+
+        return jsonObject.toString(2)
     }
-    
-    /**
-     * 从JSON字符串解析配置
-     */
+
     fun parseConfigFromJson(jsonString: String): KpmAutoLoadConfig? {
         return try {
             val jsonObject = JSONObject(jsonString)
             val enabled = jsonObject.optBoolean("enabled", false)
-            
+
             val kpmPaths = mutableListOf<String>()
             val pathsArray = jsonObject.optJSONArray("kpmPaths")
             if (pathsArray != null) {
                 for (i in 0 until pathsArray.length()) {
                     pathsArray.optString(i)?.let { path ->
-                        if (path.isNotEmpty()) {
-                            kpmPaths.add(path)
-                        }
+                        if (path.isNotEmpty()) kpmPaths.add(path)
                     }
                 }
             }
-            
+
             KpmAutoLoadConfig(enabled, kpmPaths)
         } catch (e: Exception) {
             Log.e(TAG, "解析JSON失败: ${e.message}", e)
             null
         }
-    }
-    
-    /**
-     * 在应用启动时自动加载KPM模块
-     */
-    fun autoLoadKpmModules(): Boolean {
-        Log.d(TAG, "开始检查KPM自动加载配置...")
-        Log.d(TAG, "当前状态: enabled=${isEnabled.value}, kpmPaths=${kpmPaths.value}")
-        
-        if (!isEnabled.value || kpmPaths.value.isEmpty()) {
-            Log.d(TAG, "自动加载未启用或没有配置KPM路径，跳过加载")
-            Log.d(TAG, "enabled=${isEnabled.value}, paths empty=${kpmPaths.value.isEmpty()}")
-            return false
-        }
-        
-        var successCount = 0
-        var failCount = 0
-        
-        kpmPaths.value.forEach { path ->
-            try {
-                Log.d(TAG, "尝试加载KPM: $path")
-                // 检查文件是否存在
-                val file = java.io.File(path)
-                if (!file.exists()) {
-                    Log.e(TAG, "KPM文件不存在: $path")
-                    failCount++
-                    return@forEach
-                }
-                
-                val rc = me.bmax.apatch.Natives.loadKernelPatchModule(path, "")
-                if (rc == 0L) {
-                    successCount++
-                    Log.d(TAG, "KPM加载成功: $path")
-                } else {
-                    failCount++
-                    Log.e(TAG, "KPM加载失败: $path, rc=$rc")
-                }
-            } catch (e: Exception) {
-                failCount++
-                Log.e(TAG, "KPM加载异常: $path, ${e.message}", e)
-            }
-        }
-        
-        Log.i(TAG, "KPM自动加载完成: 成功=$successCount, 失败=$failCount")
-        return successCount > 0
-    }
-    
-    /**
-     * 调试方法：检查当前配置状态
-     */
-    fun debugConfigState() {
-        Log.d(TAG, "=== KPM配置状态调试 ===")
-        Log.d(TAG, "enabled=${isEnabled.value}")
-        Log.d(TAG, "kpmPaths size=${kpmPaths.value.size}")
-        kpmPaths.value.forEachIndexed { index, path ->
-            Log.d(TAG, "路径[$index]: $path")
-        }
-        Log.d(TAG, "=== 调试结束 ===")
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -524,7 +524,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">التحميل التلقائي لـ KPM</string>
     <string name="kpm_autoload_enabled">تمكين التحميل التلقائي</string>
-    <string name="kpm_autoload_enabled_summary">تحميل وحدات KPM تلقائيًا عند بدء تشغيل التطبيق</string>
+    <string name="kpm_autoload_enabled_summary">تحميل وحدات KPM تلقائيًا عند بدء تشغيل الجهاز</string>
     <string name="kpm_autoload_json_config">تكوين JSON</string>
     <string name="kpm_autoload_json_label">تكوين JSON</string>
 <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -522,7 +522,7 @@ Aquí hay algunas posibles razones para el fallo de autenticación—por favor v
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">Auto-carga de KPM</string>
     <string name="kpm_autoload_enabled">Habilitar auto-carga</string>
-    <string name="kpm_autoload_enabled_summary">Cargar módulos KPM automáticamente al iniciar la aplicación</string>
+    <string name="kpm_autoload_enabled_summary">Cargar módulos KPM automáticamente al iniciar el dispositivo</string>
     <string name="kpm_autoload_json_config">Configuración JSON</string>
     <string name="kpm_autoload_json_label">JSON de Configuración</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -488,7 +488,7 @@ Berikut adalah beberapa kemungkinan penyebab kegagalan autentikasi—silakan cek
 
     <string name="kpm_autoload_title">Muat Otomatis KPM</string>
     <string name="kpm_autoload_enabled">Aktifkan muat otomatis</string>
-    <string name="kpm_autoload_enabled_summary">Muat modul KPM secara otomatis saat aplikasi dimulai</string>
+    <string name="kpm_autoload_enabled_summary">Muat modul KPM secara otomatis saat perangkat booting</string>
     <string name="kpm_autoload_json_config">Konfigurasi JSON</string>
     <string name="kpm_autoload_json_label">Konfigurasi JSON</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -486,7 +486,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">KPM を自動で読み込み</string>
     <string name="kpm_autoload_enabled">自動で読み込みが有効化されています</string>
-    <string name="kpm_autoload_enabled_summary">アプリの起動時に KP モジュールを自動で読み込みます。</string>
+    <string name="kpm_autoload_enabled_summary">端末の起動時に KP モジュールを自動で読み込みます。</string>
     <string name="kpm_autoload_json_config">JSON を構成</string>
     <string name="kpm_autoload_json_label">JSON を構成します</string>
     <string name="kpm_autoload_json_placeholder">{\n  \"enabled\": true,\n  \"kpmPaths\": [\n    \"/path/to/module1.kpm\",\n    \"/path/to/module2.kpm\"\n  ]\n}</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -545,7 +545,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">KPM 자동 로드</string>
     <string name="kpm_autoload_enabled">자동 로드 활성화</string>
-    <string name="kpm_autoload_enabled_summary">애플리케이션 시작 시 자동으로 KPM 모듈을 로드합니다.</string>
+    <string name="kpm_autoload_enabled_summary">기기 부팅 시 자동으로 KPM 모듈을 로드합니다.</string>
     <string name="kpm_autoload_json_config">JSON 구성</string>
     <string name="kpm_autoload_json_label">구성 JSON</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-mgl/strings.xml
+++ b/app/src/main/res/values-mgl/strings.xml
@@ -521,7 +521,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">心之结晶自动觉醒</string>
     <string name="kpm_autoload_enabled">启用结晶自主觉醒</string>
-    <string name="kpm_autoload_enabled_summary">应用启动时自动激活心之结晶</string>
+    <string name="kpm_autoload_enabled_summary">开机时自动激活心之结晶</string>
     <string name="kpm_autoload_json_config">星界咒语配置</string>
     <string name="kpm_autoload_json_label">星界咒语</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -430,7 +430,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">Automatyczne ładowanie KPM</string>
     <string name="kpm_autoload_enabled">Włącz automatyczne ładowanie</string>
-    <string name="kpm_autoload_enabled_summary">Automatycznie ładuj moduły KPM przy starcie aplikacji</string>
+    <string name="kpm_autoload_enabled_summary">Automatycznie ładuj moduły KPM przy uruchomieniu urządzenia</string>
     <string name="settings_grid_working_card_hide_check">Ukryj ikonę statusu</string>
     <string name="settings_grid_working_card_hide_check_summary">Ukryj znacznik wyboru lub ikonę ostrzeżenia na karcie roboczej</string>
     <string name="settings_grid_working_card_hide_text">Ukryj tekst statusu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -520,7 +520,7 @@ Aqui estão algumas possíveis razões para a falha de autenticação—verifiqu
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">Auto-Carregamento KPM</string>
     <string name="kpm_autoload_enabled">Ativar auto-carregamento</string>
-    <string name="kpm_autoload_enabled_summary">Carregar módulos KPM automaticamente ao iniciar o aplicativo</string>
+    <string name="kpm_autoload_enabled_summary">Carregar módulos KPM automaticamente ao iniciar o dispositivo</string>
     <string name="kpm_autoload_json_config">Configuração JSON</string>
     <string name="kpm_autoload_json_label">JSON de Configuração</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -510,7 +510,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">Автозагрузка KPM</string>
     <string name="kpm_autoload_enabled">Включить автозагрузку</string>
-    <string name="kpm_autoload_enabled_summary">Автоматически загружать модули KPM при запуске приложения</string>
+    <string name="kpm_autoload_enabled_summary">Автоматически загружать модули KPM при загрузке устройства</string>
     <string name="kpm_autoload_json_config">Конфигурация JSON</string>
     <string name="kpm_autoload_json_label">Конфигурация JSON</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -521,7 +521,7 @@ Bol şans! Ayrıca, aşağıdaki belge butonuna tıklamak kesinlikle doğru!</st
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">KPM Otomatik Yükleme</string>
     <string name="kpm_autoload_enabled">Otomatik yüklemeyi etkinleştir</string>
-    <string name="kpm_autoload_enabled_summary">Uygulama başlatıldığında KPM modüllerini otomatik olarak yükle</string>
+    <string name="kpm_autoload_enabled_summary">Cihaz açıldığında KPM modüllerini otomatik olarak yükle</string>
     <string name="kpm_autoload_json_config">JSON Yapılandırması</string>
     <string name="kpm_autoload_json_label">Yapılandırma JSON’u</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -533,7 +533,7 @@ Dưới đây là một số nguyên nhân có thể gây ra thất bại xác t
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">Tải tự động KPM</string>
     <string name="kpm_autoload_enabled">Bật tải tự động</string>
-    <string name="kpm_autoload_enabled_summary">Tự động tải module KPM khi ứng dụng khởi chạy</string>
+    <string name="kpm_autoload_enabled_summary">Tự động tải module KPM khi khởi động máy</string>
     <string name="kpm_autoload_json_config">Cấu hình JSON</string>
     <string name="kpm_autoload_json_label">Cấu hình JSON</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-zh-rAG/strings.xml
+++ b/app/src/main/res/values-zh-rAG/strings.xml
@@ -537,7 +537,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">KPM自动加载喵</string>
     <string name="kpm_autoload_enabled">开自动加载喵</string>
-    <string name="kpm_autoload_enabled_summary">应用开了就自动加载KPM模块哒喵！</string>
+    <string name="kpm_autoload_enabled_summary">开机就自动加载KPM模块哒喵！</string>
     <string name="kpm_autoload_json_config">JSON配置喵</string>
     <string name="kpm_autoload_json_label">JSON配置喵</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-zh-rAT/strings.xml
+++ b/app/src/main/res/values-zh-rAT/strings.xml
@@ -512,7 +512,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">心之结晶自动觉醒</string>
     <string name="kpm_autoload_enabled">启用结晶自主觉醒</string>
-    <string name="kpm_autoload_enabled_summary">应用启动时自动激活心之结晶</string>
+    <string name="kpm_autoload_enabled_summary">开机时自动激活心之结晶</string>
     <string name="kpm_autoload_json_config">星界咒语配置</string>
     <string name="kpm_autoload_json_label">星界咒语</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-zh-rCK/strings.xml
+++ b/app/src/main/res/values-zh-rCK/strings.xml
@@ -524,7 +524,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">酱料自动添加</string>
     <string name="kpm_autoload_enabled">启用自动添加</string>
-    <string name="kpm_autoload_enabled_summary">餐厅启动时自动添加酱料</string>
+    <string name="kpm_autoload_enabled_summary">开餐时自动添加酱料</string>
     <string name="kpm_autoload_json_config">JSON 菜谱配置</string>
     <string name="kpm_autoload_json_label">JSON 菜谱配置</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -525,7 +525,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">KPM自动加载</string>
     <string name="kpm_autoload_enabled">启用自动加载</string>
-    <string name="kpm_autoload_enabled_summary">应用启动时自动加载KPM模块</string>
+    <string name="kpm_autoload_enabled_summary">开机时自动加载KPM模块</string>
     <string name="kpm_autoload_json_config">JSON配置</string>
     <string name="kpm_autoload_json_label">JSON配置</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-zh-rMC/strings.xml
+++ b/app/src/main/res/values-zh-rMC/strings.xml
@@ -524,7 +524,7 @@
     <!-- KPM 自动加载 -->
     <string name="kpm_autoload_title">红石组件自动充能</string>
     <string name="kpm_autoload_enabled">开启自动充能</string>
-    <string name="kpm_autoload_enabled_summary">服务器启动时自动给红石组件充能</string>
+    <string name="kpm_autoload_enabled_summary">世界加载时自动给红石组件充能</string>
     <string name="kpm_autoload_json_config">JSON配置</string>
     <string name="kpm_autoload_json_label">JSON配置</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -490,7 +490,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">KPM 自動載入</string>
     <string name="kpm_autoload_enabled">啟用自動載入</string>
-    <string name="kpm_autoload_enabled_summary">應用程式啟動時自動載入 KPM 模組</string>
+    <string name="kpm_autoload_enabled_summary">開機時自動載入 KPM 模組</string>
     <string name="kpm_autoload_json_config">JSON 設定</string>
     <string name="kpm_autoload_json_label">JSON 設定</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values-zh-rWC/strings.xml
+++ b/app/src/main/res/values-zh-rWC/strings.xml
@@ -516,7 +516,7 @@
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">道核仙符自动引符</string>
     <string name="kpm_autoload_enabled">启自动引符</string>
-    <string name="kpm_autoload_enabled_summary">仙器启时，自动引道核仙符入道</string>
+    <string name="kpm_autoload_enabled_summary">重铸仙躯时，自动引道核仙符入道</string>
     <string name="kpm_autoload_json_config">JSON天机典式</string>
     <string name="kpm_autoload_json_label">JSON天机典式</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -545,7 +545,7 @@ Here are some possible reasons for authentication failure—please check which o
     <!-- KPM AutoLoad Strings -->
     <string name="kpm_autoload_title">KPM Auto-Load</string>
     <string name="kpm_autoload_enabled">Enable auto-load</string>
-    <string name="kpm_autoload_enabled_summary">Automatically load KPM modules on application startup</string>
+    <string name="kpm_autoload_enabled_summary">Automatically load KPM modules on boot</string>
     <string name="kpm_autoload_json_config">JSON Configuration</string>
     <string name="kpm_autoload_json_label">Configuration JSON</string>
     <string name="kpm_autoload_json_placeholder">{

--- a/fpd/src/main.rs
+++ b/fpd/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
             .unwrap_or("");
         match name {
             "hide" => return prop_patch::run(),
-            "umount" => return std::process::exit(umount::run() as i32),
+            "umount" => std::process::exit(umount::run() as i32),
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

- **KPM Autoload**: 在 APD 服务阶段实现 KPM 模块自动加载，含 SELinux 适配、安全加固（文件名清理、路径规范化、模块上限）和 Android 兼容性修复
- **CI/CD**: 统一构建工作流，使用 matrix 策略 + composite action 复用环境配置，移除冗余 Zig 依赖和 GitHub Release 步骤
- **Bug Fix**: 移除 fpd main.rs umount 分支中不可达的 return 语句

## Details

### KPM Autoload (`d6224768`)
- 将 KPM autoload 从 App 层迁移至 APD 服务阶段（开机仅加载一次）
- 配置路径迁移至 `/data/adb/fp/kpms/` 以适配 SELinux
- 安全加固：文件名清理、Base64 配置写入、路径规范化、模块数量上限 (64)
- Android 兼容性：使用 `android.util.Base64` 替代 `java.util.Base64`
- 修复 `.to(null,null)` 导致 stdout 被丢弃的配置加载问题
- 更新所有语言（19 个 locale）的 autoload 描述文案

### CI/CD (`db880549`)
- 使用 matrix 策略合并 debug/release 构建任务
- 抽取公共构建环境为可复用 composite action
- 彻底移除残留的 Zig 依赖（Zig 服务已由 fpd 替代）
- Telegram 上传增加未配置时的跳过守卫

### Fix (`bc4ad8db`)
- 移除 `fpd/src/main.rs` umount 分支中的不可达 return