### PR TITLE
修复APM模块页面独立卡片模式点击显示问题

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
@@ -1793,7 +1793,9 @@ private fun ModuleItem(
         }
     } else {
         Surface(
-            modifier = modifier.then(clickModifier),
+            modifier = modifier
+                .clip(cardShape)
+                .then(clickModifier),
             shape = cardShape,
             color = cardColor,
             tonalElevation = 0.dp


### PR DESCRIPTION
修复APM模块页面独立卡片(关闭m3e拼接)模式下点击卡片特效波纹显示为矩形超出圆角问题