### PR TITLE
修复kpm模块界面点击特效越界问题

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/KPM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/KPM.kt
@@ -1321,7 +1321,9 @@ private fun KPModuleItem(
         }
     } else {
         Surface(
-            modifier = modifier.then(clickModifier),
+            modifier = modifier
+                .clip(cardShape)
+                .then(clickModifier),
             shape = cardShape,
             color = cardColor,
             tonalElevation = 0.dp


### PR DESCRIPTION
修复kpm模块界面 独立卡片模式下 点击卡片阴影特效矩形，而卡片有圆角导致阴影超出卡片边角越界问题