### PR TITLE
fix: resolve NoSuchMethodError for Application.getProcessName() on AP…

### DIFF
--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -1,10 +1,12 @@
 package me.bmax.apatch
 
+import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
+import android.os.Process
 import android.util.Log
 import me.bmax.apatch.util.ui.showToast
 import androidx.core.content.edit
@@ -344,7 +346,8 @@ class APApplication : Application(), Thread.UncaughtExceptionHandler, ImageLoade
         apApp = this
         sharedPreferences = getSharedPreferences(SP_NAME, Context.MODE_PRIVATE)
         superKey = "su"
-        if (Application.getProcessName().endsWith(":root") || Application.getProcessName().endsWith(":webui")) {
+        val processName = getProcessNameCompat()
+        if (processName.endsWith(":root") || processName.endsWith(":webui")) {
             return
         }
         bypassHiddenApiRestrictions()
@@ -429,6 +432,21 @@ class APApplication : Application(), Thread.UncaughtExceptionHandler, ImageLoade
 
     fun updateBackupWarningState(state: Boolean) {
         sharedPreferences.edit { putBoolean(SHOW_BACKUP_WARN, state) }
+    }
+
+    /**
+     * Compatibility helper to get the current process name.
+     * Application.getProcessName() is only available from API 28 (Android P).
+     * On API 26-27, fall back to ActivityManager.getRunningAppProcesses().
+     */
+    private fun getProcessNameCompat(): String {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return Application.getProcessName()
+        }
+        // Fallback for API 26-27
+        val am = getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager ?: return packageName
+        val pid = Process.myPid()
+        return am.runningAppProcesses?.find { it.pid == pid }?.processName ?: packageName
     }
 
     override fun uncaughtException(t: Thread, e: Throwable) {

--- a/app/src/main/java/me/bmax/apatch/util/SafeFileProvider.kt
+++ b/app/src/main/java/me/bmax/apatch/util/SafeFileProvider.kt
@@ -1,17 +1,21 @@
 package me.bmax.apatch.util
 
+import android.app.ActivityManager
 import android.app.Application
+import android.content.Context
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
+import android.os.Build
 import android.os.ParcelFileDescriptor
+import android.os.Process
 import androidx.core.content.FileProvider
 
 class SafeFileProvider : FileProvider() {
     private var shouldInit = false
 
     override fun onCreate(): Boolean {
-        val processName = Application.getProcessName()
+        val processName = getProcessNameCompat()
         shouldInit = !processName.endsWith(":root") && !processName.endsWith(":webui")
         if (!shouldInit) return false
         return try {
@@ -48,5 +52,21 @@ class SafeFileProvider : FileProvider() {
         } catch (e: Exception) {
             null
         }
+    }
+
+    /**
+     * Compatibility helper to get the current process name.
+     * Application.getProcessName() is only available from API 28 (Android P).
+     * On API 26-27, fall back to ActivityManager.getRunningAppProcesses().
+     */
+    private fun getProcessNameCompat(): String {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return Application.getProcessName()
+        }
+        // Fallback for API 26-27
+        val context = context ?: return ""
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager ?: return ""
+        val pid = Process.myPid()
+        return am.runningAppProcesses?.find { it.pid == pid }?.processName ?: context.packageName
     }
 }


### PR DESCRIPTION
…I 26-27

Application.getProcessName() is only available from API 28 (Android P). On devices running API 26-27 (Android Oreo), calling this method directly causes NoSuchMethodError crash at app startup in SafeFileProvider.

- SafeFileProvider.kt: Use getProcessNameCompat() with fallback to ActivityManager.getRunningAppProcesses() for API < 28
- APatchApp.kt: Same compatibility fix for process name detection