### PR TITLE
fix: defer loadUrl until WebView is laid out and support insets

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/WebUIActivity.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/WebUIActivity.kt
@@ -8,7 +8,9 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.view.ViewGroup.MarginLayoutParams
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
@@ -16,35 +18,49 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.webkit.WebViewAssetLoader
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import me.bmax.apatch.APApplication
 import me.bmax.apatch.ui.theme.APatchTheme
 import me.bmax.apatch.ui.viewmodel.SuperUserViewModel
 import me.bmax.apatch.ui.webui.AppIconUtil
+import me.bmax.apatch.ui.webui.Insets
 import me.bmax.apatch.ui.webui.SuFilePathHandler
 import me.bmax.apatch.ui.webui.WebViewInterface
 import java.io.ByteArrayInputStream
@@ -58,7 +74,10 @@ class WebUIActivity : AppCompatActivity() {
     private var webCanGoBack = false
     private lateinit var fileChooserLauncher: ActivityResultLauncher<Intent>
     private var filePathCallback: ValueCallback<Array<Uri>>? = null
+    private var isUrlLoaded = false
     private var isWebViewReady by mutableStateOf(false)
+    private var isInsetsEnabled by mutableStateOf(false)
+    private var currentInsets by mutableStateOf(Insets(0, 0, 0, 0))
 
     override fun onCreate(savedInstanceState: Bundle?) {
 
@@ -66,6 +85,7 @@ class WebUIActivity : AppCompatActivity() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             window.isNavigationBarContrastEnforced = false
         }
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
 
         val prefs = APApplication.sharedPreferences
         val nightModeFollowSys = prefs.getBoolean("night_mode_follow_sys", false)
@@ -80,7 +100,7 @@ class WebUIActivity : AppCompatActivity() {
         AppCompatDelegate.setDefaultNightMode(mode)
 
         super.onCreate(savedInstanceState)
-        
+
         setupActivityInfo()
 
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
@@ -97,31 +117,83 @@ class WebUIActivity : AppCompatActivity() {
         setContent {
             APatchTheme(allowCustomBackground = false) {
                 val backgroundColor = MaterialTheme.colorScheme.background
+                val density = LocalDensity.current
+                val layoutDirection = LocalLayoutDirection.current
+                val drawingInsets = WindowInsets.safeDrawing
+                val systemBarsInsets = WindowInsets.systemBars
+                val imeInsets = WindowInsets.ime
+                val innerPadding = if (isInsetsEnabled) {
+                    imeInsets.asPaddingValues()
+                } else {
+                    drawingInsets.asPaddingValues()
+                }
+
+                LaunchedEffect(density, layoutDirection, systemBarsInsets, isInsetsEnabled) {
+                    if (!isInsetsEnabled) return@LaunchedEffect
+                    snapshotFlow {
+                        val top = (systemBarsInsets.getTop(density) / density.density).toInt()
+                        val bottom = (systemBarsInsets.getBottom(density) / density.density).toInt()
+                        val left = (systemBarsInsets.getLeft(density, layoutDirection) / density.density).toInt()
+                        val right = (systemBarsInsets.getRight(density, layoutDirection) / density.density).toInt()
+                        Insets(top, bottom, left, right)
+                    }.collect { newInsets ->
+                        if (currentInsets != newInsets) {
+                            currentInsets = newInsets
+                            webView?.evaluateJavascript(newInsets.js, null)
+                        }
+                    }
+                }
+
                 Box(
-                    modifier = Modifier.fillMaxSize().background(backgroundColor),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(backgroundColor)
+                        .padding(innerPadding),
                     contentAlignment = Alignment.Center
                 ) {
                     if (isWebViewReady) {
                         AndroidView(
-                            modifier = Modifier.fillMaxSize().systemBarsPadding(),
-                            factory = { context ->
-                                WebView(context).apply {
-                                    layoutParams = android.view.ViewGroup.LayoutParams(
-                                        android.view.ViewGroup.LayoutParams.MATCH_PARENT,
-                                        android.view.ViewGroup.LayoutParams.MATCH_PARENT
+                            modifier = Modifier.fillMaxSize(),
+                            factory = { _ ->
+                                webView!!.apply {
+                                    layoutParams = ViewGroup.LayoutParams(
+                                        ViewGroup.LayoutParams.MATCH_PARENT,
+                                        ViewGroup.LayoutParams.MATCH_PARENT
                                     )
-                                    this@WebUIActivity.webView = this
-                                    configureWebView(this)
+                                    if (!isUrlLoaded) {
+                                        val homePage = "https://mui.kernelsu.org/index.html"
+                                        if (width > 0 && height > 0) {
+                                            loadUrl(homePage)
+                                            isUrlLoaded = true
+                                        } else {
+                                            val listener = object : View.OnLayoutChangeListener {
+                                                override fun onLayoutChange(
+                                                    v: View, left: Int, top: Int, right: Int, bottom: Int,
+                                                    oldLeft: Int, oldTop: Int, oldRight: Int, oldBottom: Int
+                                                ) {
+                                                    if (v.width > 0 && v.height > 0) {
+                                                        (v as WebView).loadUrl(homePage)
+                                                        isUrlLoaded = true
+                                                        v.removeOnLayoutChangeListener(this)
+                                                    }
+                                                }
+                                            }
+                                            addOnLayoutChangeListener(listener)
+                                        }
+                                    }
                                 }
                             },
                             update = { view ->
-                                view.setBackgroundColor(backgroundColor.toArgb())
+                                view.requestLayout()
                             }
                         )
                     } else {
                         CircularProgressIndicator()
                     }
                 }
+
+                HandleWebViewLifecycle()
+                HandleConfigurationChanges()
             }
         }
 
@@ -129,7 +201,7 @@ class WebUIActivity : AppCompatActivity() {
             if (SuperUserViewModel.apps.isEmpty()) {
                 SuperUserViewModel().fetchAppList()
             }
-            isWebViewReady = true
+            prepareWebView()
         }
 
         fileChooserLauncher = registerForActivityResult(
@@ -165,84 +237,128 @@ class WebUIActivity : AppCompatActivity() {
         }
     }
 
-    private fun configureWebView(webView: WebView) {
+    @Composable
+    private fun HandleWebViewLifecycle() {
+        val lifecycleOwner = LocalLifecycleOwner.current
+        DisposableEffect(lifecycleOwner, webView) {
+            val observer = LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_RESUME -> webView?.onResume()
+                    Lifecycle.Event.ON_PAUSE -> webView?.onPause()
+                    else -> {}
+                }
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose {
+                lifecycleOwner.lifecycle.removeObserver(observer)
+            }
+        }
+    }
+
+    @Composable
+    private fun HandleConfigurationChanges() {
+        val configuration = LocalConfiguration.current
+        LaunchedEffect(configuration.fontScale, webView) {
+            webView?.settings?.textZoom = (configuration.fontScale * 100).toInt()
+        }
+    }
+
+    private suspend fun prepareWebView() {
         val moduleId = intent.getStringExtra("id")!!
 
-        val prefs = APApplication.sharedPreferences
-        WebView.setWebContentsDebuggingEnabled(prefs.getBoolean("enable_web_debugging", false))
-
-        val webRoot = File("/data/adb/modules/${moduleId}/webroot")
-        val webViewAssetLoader = WebViewAssetLoader.Builder()
-            .setDomain("mui.kernelsu.org")
-            .addPathHandler(
-                "/",
-                SuFilePathHandler(this, webRoot)
-            )
-            .build()
-
-        val webViewClient = object : WebViewClient() {
-            override fun shouldInterceptRequest(
-                view: WebView,
-                request: WebResourceRequest
-            ): WebResourceResponse? {
-                val url = request.url
-
-                // Handle ksu://icon/[packageName] to serve app icon via WebView
-                if (url.scheme.equals("ksu", ignoreCase = true) && url.host.equals("icon", ignoreCase = true)) {
-                    val packageName = url.path?.substring(1)
-                    if (!packageName.isNullOrEmpty()) {
-                        val icon = AppIconUtil.loadAppIconSync(this@WebUIActivity, packageName, 512)
-                        if (icon != null) {
-                            val stream = ByteArrayOutputStream()
-                            icon.compress(Bitmap.CompressFormat.PNG, 100, stream)
-                            return WebResourceResponse(
-                                "image/png", null, 200, "OK",
-                                mapOf("Access-Control-Allow-Origin" to "*"),
-                                ByteArrayInputStream(stream.toByteArray())
-                            )
-                        }
-                    }
-                }
-
-                return webViewAssetLoader.shouldInterceptRequest(request.url)
-            }
-
-            override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
-                webCanGoBack = view?.canGoBack() == true
-                super.doUpdateVisitedHistory(view, url, isReload)
+        withContext(Dispatchers.IO) {
+            if (SuperUserViewModel.apps.isEmpty()) {
+                SuperUserViewModel().fetchAppList()
             }
         }
 
-        webView.apply {
-            settings.javaScriptEnabled = true
-            settings.domStorageEnabled = true
-            settings.allowFileAccess = false
-            webViewInterface = WebViewInterface(this@WebUIActivity, this)
-            addJavascriptInterface(webViewInterface, "ksu")
-            setWebViewClient(webViewClient)
-            webChromeClient = object : WebChromeClient() {
-                override fun onShowFileChooser(
-                    webView: WebView?,
-                    filePathCallback: ValueCallback<Array<Uri>>?,
-                    fileChooserParams: FileChooserParams?
-                ): Boolean {
-                    this@WebUIActivity.filePathCallback?.onReceiveValue(null)
-                    this@WebUIActivity.filePathCallback = filePathCallback
-                    val intent = fileChooserParams?.createIntent() ?: Intent(Intent.ACTION_GET_CONTENT).apply { type = "*/*" }
-                    if (fileChooserParams?.mode == FileChooserParams.MODE_OPEN_MULTIPLE) {
-                        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        withContext(Dispatchers.Main) {
+            val prefs = APApplication.sharedPreferences
+            WebView.setWebContentsDebuggingEnabled(prefs.getBoolean("enable_web_debugging", false))
+
+            val webRoot = File("/data/adb/modules/${moduleId}/webroot")
+
+            val newWebView = WebView(this@WebUIActivity).apply {
+                setBackgroundColor(android.graphics.Color.TRANSPARENT)
+
+                settings.javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                settings.allowFileAccess = false
+
+                val webViewAssetLoader = WebViewAssetLoader.Builder()
+                    .setDomain("mui.kernelsu.org")
+                    .addPathHandler(
+                        "/",
+                        SuFilePathHandler(
+                            this@WebUIActivity,
+                            webRoot,
+                            { currentInsets },
+                            { enable -> isInsetsEnabled = enable }
+                        )
+                    )
+                    .build()
+
+                webViewClient = object : WebViewClient() {
+                    override fun shouldInterceptRequest(
+                        view: WebView,
+                        request: WebResourceRequest
+                    ): WebResourceResponse? {
+                        val url = request.url
+
+                        if (url.scheme.equals("ksu", ignoreCase = true) && url.host.equals("icon", ignoreCase = true)) {
+                            val packageName = url.path?.substring(1)
+                            if (!packageName.isNullOrEmpty()) {
+                                val icon = AppIconUtil.loadAppIconSync(this@WebUIActivity, packageName, 512)
+                                if (icon != null) {
+                                    val stream = ByteArrayOutputStream()
+                                    icon.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                                    return WebResourceResponse(
+                                        "image/png", null, 200, "OK",
+                                        mapOf("Access-Control-Allow-Origin" to "*"),
+                                        ByteArrayInputStream(stream.toByteArray())
+                                    )
+                                }
+                            }
+                        }
+
+                        return webViewAssetLoader.shouldInterceptRequest(url)
                     }
-                    try {
-                        fileChooserLauncher.launch(intent)
-                    } catch (_: ActivityNotFoundException) {
-                        filePathCallback?.onReceiveValue(null)
-                        this@WebUIActivity.filePathCallback = null
-                        return false
+
+                    override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+                        webCanGoBack = view?.canGoBack() == true
+                        if (isInsetsEnabled) webView?.evaluateJavascript(currentInsets.js, null)
+                        super.doUpdateVisitedHistory(view, url, isReload)
                     }
-                    return true
+                }
+
+                webChromeClient = object : WebChromeClient() {
+                    override fun onShowFileChooser(
+                        webView: WebView?,
+                        filePathCallback: ValueCallback<Array<Uri>>?,
+                        fileChooserParams: FileChooserParams?
+                    ): Boolean {
+                        this@WebUIActivity.filePathCallback?.onReceiveValue(null)
+                        this@WebUIActivity.filePathCallback = filePathCallback
+                        val intent = fileChooserParams?.createIntent() ?: Intent(Intent.ACTION_GET_CONTENT).apply { type = "*/*" }
+                        if (fileChooserParams?.mode == FileChooserParams.MODE_OPEN_MULTIPLE) {
+                            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                        }
+                        try {
+                            fileChooserLauncher.launch(intent)
+                        } catch (_: ActivityNotFoundException) {
+                            filePathCallback?.onReceiveValue(null)
+                            this@WebUIActivity.filePathCallback = null
+                            return false
+                        }
+                        return true
+                    }
                 }
             }
-            loadUrl("https://mui.kernelsu.org/index.html")
+
+            webViewInterface = WebViewInterface(this@WebUIActivity, newWebView) { enable -> isInsetsEnabled = enable }
+            newWebView.addJavascriptInterface(webViewInterface, "ksu")
+            this@WebUIActivity.webView = newWebView
+            isWebViewReady = true
         }
     }
 }

--- a/app/src/main/java/me/bmax/apatch/ui/webui/Insets.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/webui/Insets.kt
@@ -1,0 +1,36 @@
+package me.bmax.apatch.ui.webui
+
+data class Insets(
+    val top: Int,
+    val bottom: Int,
+    val left: Int,
+    val right: Int,
+) {
+    val css
+        get() = buildString {
+            appendLine(":root {")
+            appendLine("\t--safe-area-inset-top: ${top}px;")
+            appendLine("\t--safe-area-inset-right: ${right}px;")
+            appendLine("\t--safe-area-inset-bottom: ${bottom}px;")
+            appendLine("\t--safe-area-inset-left: ${left}px;")
+            appendLine("\t--window-inset-top: var(--safe-area-inset-top, 0px);")
+            appendLine("\t--window-inset-bottom: var(--safe-area-inset-bottom, 0px);")
+            appendLine("\t--window-inset-left: var(--safe-area-inset-left, 0px);")
+            appendLine("\t--window-inset-right: var(--safe-area-inset-right, 0px);")
+            appendLine("\t--f7-safe-area-top: var(--window-inset-top, 0px) !important;")
+            appendLine("\t--f7-safe-area-bottom: var(--window-inset-bottom, 0px) !important;")
+            appendLine("\t--f7-safe-area-left: var(--window-inset-left, 0px) !important;")
+            append("\t--f7-safe-area-right: var(--window-inset-right, 0px) !important;")
+            appendLine("}")
+        }
+    val js
+        get() = buildString {
+            append("(function() {")
+            append(" var s = document.documentElement.style;")
+            append(" s.setProperty('--safe-area-inset-top', '${top}px');")
+            append(" s.setProperty('--safe-area-inset-right', '${right}px');")
+            append(" s.setProperty('--safe-area-inset-bottom', '${bottom}px');")
+            append(" s.setProperty('--safe-area-inset-left', '${left}px');")
+            append("})();")
+        }
+}

--- a/app/src/main/java/me/bmax/apatch/ui/webui/SuFilePathHandler.java
+++ b/app/src/main/java/me/bmax/apatch/ui/webui/SuFilePathHandler.java
@@ -12,10 +12,12 @@ import com.topjohnwu.superuser.Shell;
 import com.topjohnwu.superuser.io.SuFile;
 import com.topjohnwu.superuser.io.SuFileInputStream;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 
 import me.bmax.apatch.util.APatchCliKt;
@@ -61,6 +63,17 @@ public final class SuFilePathHandler implements WebViewAssetLoader.PathHandler {
     private final File mDirectory;
 
     private final Shell mShell;
+    private final InsetsSupplier mInsetsSupplier;
+    private final OnInsetsRequestedListener mOnInsetsRequestedListener;
+
+    public interface InsetsSupplier {
+        @NonNull
+        Insets get();
+    }
+
+    public interface OnInsetsRequestedListener {
+        void onInsetsRequested(boolean enable);
+    }
 
     /**
      * Creates PathHandler for app's internal storage.
@@ -82,10 +95,14 @@ public final class SuFilePathHandler implements WebViewAssetLoader.PathHandler {
      * @param context {@link Context} that is used to access app's internal storage.
      * @param directory the absolute path of the exposed app internal storage directory from
      *                  which files can be loaded.
+     * @param insetsSupplier {@link InsetsSupplier} to provide window insets for styling web content.
+     * @param onInsetsRequestedListener {@link OnInsetsRequestedListener} to notify when insets are requested.
      * @throws IllegalArgumentException if the directory is not allowed.
      */
-    public SuFilePathHandler(@NonNull Context context, @NonNull File directory) {
+    public SuFilePathHandler(@NonNull Context context, @NonNull File directory, @NonNull InsetsSupplier insetsSupplier, @NonNull OnInsetsRequestedListener onInsetsRequestedListener) {
         try {
+            mInsetsSupplier = insetsSupplier;
+            mOnInsetsRequestedListener = onInsetsRequestedListener;
             mDirectory = new File(getCanonicalDirPath(directory));
             if (!isAllowedInternalStorageDir(context)) {
                 throw new IllegalArgumentException("The given directory \"" + directory
@@ -133,12 +150,23 @@ public final class SuFilePathHandler implements WebViewAssetLoader.PathHandler {
     @WorkerThread
     @NonNull
     public WebResourceResponse handle(@NonNull String path) {
+        if ("internal/insets.css".equals(path)) {
+            if (mOnInsetsRequestedListener != null) {
+                mOnInsetsRequestedListener.onInsetsRequested(true);
+            }
+            String css = mInsetsSupplier.get().getCss();
+            return new WebResourceResponse(
+                    "text/css",
+                    "utf-8",
+                    new ByteArrayInputStream(css.getBytes(StandardCharsets.UTF_8))
+            );
+        }
         if ("internal/colors.css".equals(path)) {
             String css = MonetColorsProvider.INSTANCE.getColorsCss();
             return new WebResourceResponse(
                 "text/css",
                 "utf-8",
-                new java.io.ByteArrayInputStream(css.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                new ByteArrayInputStream(css.getBytes(StandardCharsets.UTF_8))
             );
         }
         try {

--- a/app/src/main/java/me/bmax/apatch/ui/webui/WebViewInterface.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/webui/WebViewInterface.kt
@@ -22,7 +22,11 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.CompletableFuture
 
-class WebViewInterface(val context: Context, private val webView: WebView) {
+class WebViewInterface(
+    val context: Context,
+    private val webView: WebView,
+    private val onInsetsEnabledChanged: ((Boolean) -> Unit)? = null
+) {
     @JavascriptInterface
     fun exec(cmd: String): String {
         val shell = createRootShellStrict(reason = "WebUI exec")
@@ -154,15 +158,22 @@ class WebViewInterface(val context: Context, private val webView: WebView) {
 
     @JavascriptInterface
     fun fullScreen(enable: Boolean) {
-        if (context is Activity) {
+        val ctx = webView.context
+        if (ctx is Activity) {
             Handler(Looper.getMainLooper()).post {
                 if (enable) {
-                    hideSystemUI(context.window)
+                    hideSystemUI(ctx.window)
                 } else {
-                    showSystemUI(context.window)
+                    showSystemUI(ctx.window)
                 }
             }
         }
+        enableEdgeToEdge(enable)
+    }
+
+    @JavascriptInterface
+    fun enableEdgeToEdge(enable: Boolean = true) {
+        onInsetsEnabledChanged?.invoke(enable)
     }
 
     @JavascriptInterface


### PR DESCRIPTION
The WebUI failed to load CSS/JS assets because the WebView was configured and loadUrl was called inside the AndroidView factory during Compose composition, which blocked the main thread and called loadUrl before the WebView had valid dimensions. Refactor to match the KernelSU pattern:
- Create WebView and configure WebViewAssetLoader on IO dispatcher
- Build WebView fully on Main thread outside AndroidView
- Defer loadUrl until width > 0 && height > 0 via layout listener

Besides, ported insets feature related from KernelSU
- related:
  - tiann/KernelSU#2952
  - tiann/KernelSU#3083
  - tiann/KernelSU#3126
  - tiann/KernelSU#3190